### PR TITLE
Fix syntax in README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ read('foo.txt', 'utf8', function(err, buffer) {
 });
 
 // or
-read('foo.txt', {encoding: 'utf8'} function(err, buffer) {
+read('foo.txt', {encoding: 'utf8'}, function(err, buffer) {
   //=> 'some contents...'
 });
 ```


### PR DESCRIPTION
Added missing comma which resulted in SyntaxError.
